### PR TITLE
Patch for decoding invalid utf-8 data

### DIFF
--- a/packages/util/src/__tests__/string.spec.ts
+++ b/packages/util/src/__tests__/string.spec.ts
@@ -40,6 +40,12 @@ describe('String Conversions', () => {
             }
         });
 
+        test('should not convertByteArrayToString() with invalid utf-8 data', () => {
+            expect(() => {
+                convertByteArrayToString(TestBytes, 14)
+            }).toThrowError('Error decoding utf-8 data');
+        });
+
     });
 
     describe('convertBase36ToString', () => {

--- a/packages/util/src/convertByteArrayToString.ts
+++ b/packages/util/src/convertByteArrayToString.ts
@@ -24,7 +24,12 @@ export const convertByteArrayToString = (byteArray: Uint8Array, startIndex: numb
         bytes = byteArray.slice(startIndex, startIndex + len);
     }
 
-    return decodeURIComponent(escape(String.fromCharCode.apply(null, Array.from(bytes))));
+    const escapedUTF8 = escape(String.fromCharCode.apply(null, Array.from(bytes)));
+    try {
+        return decodeURIComponent(escapedUTF8)
+    } catch (e) {
+        throw new Error('Error decoding utf-8 data');
+    }
 };
 
 


### PR DESCRIPTION
There is some cases that can lead the decoding process of utf-8 strings to fail. This happens when the rules for decoding does not apply. A testcase is proposed with a sliced part of byte array that is invalid for decoding (the sliced part takes just between a multi byte character).

This will cause decodeURIComponent to throw anyway (a message `URI malformed`), but this patch enable to send another error message more specific, as proposed.