### PR TITLE
fix: fee override for encrypted messages

### DIFF
--- a/packages/wallets/src/extension/args/requestSendEncryptedMessageArgs.ts
+++ b/packages/wallets/src/extension/args/requestSendEncryptedMessageArgs.ts
@@ -7,4 +7,5 @@ export interface RequestSendEncryptedMessageArgs {
     plainMessage: string;
     messageIsText: boolean;
     recipientPublicKey: string;
+    feeSigna?: string;
 }

--- a/packages/wallets/src/extension/genericExtensionWallet.ts
+++ b/packages/wallets/src/extension/genericExtensionWallet.ts
@@ -153,10 +153,12 @@ export class GenericExtensionWallet implements Wallet {
      */
     async sendEncryptedMessage(args: SendEncryptedMessageArgs): Promise<ConfirmedTransaction> {
         this.assertConnection();
+        const feeSigna = args.feeSigna === 'number' ? args.feeSigna.toString() : args.feeSigna as string;
         const result = await this.adapter.requestSendEncryptedMessage({
             plainMessage: args.message || args.hexMessage,
             messageIsText: !!args.message,
-            recipientPublicKey: args.recipientPublicKey
+            recipientPublicKey: args.recipientPublicKey,
+            feeSigna,
         });
         return {...result};
     }

--- a/packages/wallets/src/extension/messaging.ts
+++ b/packages/wallets/src/extension/messaging.ts
@@ -128,6 +128,7 @@ export interface ExtensionSendEncryptedMessageRequest extends ExtensionMessageBa
     plainMessage: string;
     messageIsText: boolean;
     recipientPublicKey: string;
+    feeSigna?: string;
 }
 
 /**
@@ -324,6 +325,6 @@ export interface ExtensionNotificationAccountChanged
      * The id of the account that was removed
      */
     accountId: string;
-    accountPublicKey: string
+    accountPublicKey: string;
 }
 

--- a/packages/wallets/src/typings/args/sendEncryptedMessageArgs.ts
+++ b/packages/wallets/src/typings/args/sendEncryptedMessageArgs.ts
@@ -18,4 +18,9 @@ export interface SendEncryptedMessageArgs {
      * You can either send a text or hex message, but not both
      */
     hexMessage?: string;
+
+    /**
+     * A custom fee in Signa value. You can use this to override automatic calculation.
+     */
+    feeSigna?: string | number;
 }


### PR DESCRIPTION
added fee override for signumjs/wallets on sendEncryptedMessage