### PR TITLE
feat: support for upcoming TLD format in SRC44 implementation

### DIFF
--- a/packages/standards/src/src44/DescriptorDataBuilder.ts
+++ b/packages/standards/src/src44/DescriptorDataBuilder.ts
@@ -84,8 +84,8 @@ export class DescriptorDataBuilder {
         return this;
     }
 
-    setAlias(a: string) {
-        this.data.raw.al = a;
+    setAlias(a: string, tld?:string) {
+        this.data.raw.al = tld ? `${a}.${tld}` : a;
         return this;
     }
 

--- a/packages/standards/src/src44/DescriptorDataBuilder.ts
+++ b/packages/standards/src/src44/DescriptorDataBuilder.ts
@@ -14,7 +14,7 @@ import {DescriptorData} from './DescriptorData';
  *     .setBackground('QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc', 'image/jpeg')
  *     .setAvatar('QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR', 'image/gif')
  *     .setSocialMediaLinks(['https://somelink.com'])
- *     .setAlias('alias')
+ *     .setAlias('alias:tld') // or just 'alias' (without tld - default: signum)
  *     .setCustomField('xc', 'value')
  *     .setDescription('description')
  *     .setExtension('QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc')
@@ -84,8 +84,8 @@ export class DescriptorDataBuilder {
         return this;
     }
 
-    setAlias(a: string, tld?:string) {
-        this.data.raw.al = tld ? `${a}.${tld}` : a;
+    setAlias(a: string, tld?: string) {
+        this.data.raw.al = tld ? `${a}:${tld}` : a;
         return this;
     }
 

--- a/packages/standards/src/src44/DescriptorDataClient.ts
+++ b/packages/standards/src/src44/DescriptorDataClient.ts
@@ -321,12 +321,8 @@ export class DescriptorDataClient {
      * @throws If the alias does not have compatible descriptor data
      */
     async getFromAlias(aliasName: string): Promise<Descriptor> {
-        const tldSeparator = aliasName.indexOf(':');
-        let tld;
-        if (tldSeparator !== -1) {
-            tld = aliasName.substr(tldSeparator + 1);
-        }
-        const {aliasURI} = await this.ledger.alias.getAliasByName(aliasName, tld);
+        const [name, tld] = aliasName.split(':');
+        const {aliasURI} = await this.ledger.alias.getAliasByName(name, tld);
         return DescriptorData.parse(aliasURI).get();
     }
 

--- a/packages/standards/src/src44/DescriptorDataClient.ts
+++ b/packages/standards/src/src44/DescriptorDataClient.ts
@@ -317,11 +317,11 @@ export class DescriptorDataClient {
 
     /**
      * Gets descriptor data from an alias.
-     * @param aliasName The unique alias name (can have a TLD attached, like myalias.mytld)
+     * @param aliasName The unique alias name (can have a TLD attached using `:`, like `myalias:mytld`)
      * @throws If the alias does not have compatible descriptor data
      */
     async getFromAlias(aliasName: string): Promise<Descriptor> {
-        const tldSeparator = aliasName.indexOf('.');
+        const tldSeparator = aliasName.indexOf(':');
         let tld;
         if (tldSeparator !== -1) {
             tld = aliasName.substr(tldSeparator + 1);

--- a/packages/standards/src/src44/DescriptorDataClient.ts
+++ b/packages/standards/src/src44/DescriptorDataClient.ts
@@ -317,11 +317,16 @@ export class DescriptorDataClient {
 
     /**
      * Gets descriptor data from an alias.
-     * @param aliasName The unique alias name
+     * @param aliasName The unique alias name (can have a TLD attached, like myalias.mytld)
      * @throws If the alias does not have compatible descriptor data
      */
     async getFromAlias(aliasName: string): Promise<Descriptor> {
-        const {aliasURI} = await this.ledger.alias.getAliasByName(aliasName);
+        const tldSeparator = aliasName.indexOf('.');
+        let tld;
+        if (tldSeparator !== -1) {
+            tld = aliasName.substr(tldSeparator + 1);
+        }
+        const {aliasURI} = await this.ledger.alias.getAliasByName(aliasName, tld);
         return DescriptorData.parse(aliasURI).get();
     }
 

--- a/packages/standards/src/src44/__tests__/descriptorData.spec.ts
+++ b/packages/standards/src/src44/__tests__/descriptorData.spec.ts
@@ -27,6 +27,20 @@ const TestObjectStrict = {
     'sc': ['https://twitter.com/bittrex', 'https://twitter.com/bittrex2']
 };
 
+const TestObjectAliasTld = {
+    'vs': 1,
+    'tp': 'cex',
+    'nm': 'Bittrex',
+    'ds': 'World class exchange at your service',
+    'av': {'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR': 'image/gif'},
+    'bg': {'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc': 'image/jpeg'},
+    'hp': 'https://bittrex.com',
+    'sr': '^[0-9a-fA-F]{24}$',
+    'al': 'somealias.mytld',
+    'xt': 'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc',
+    'sc': ['https://twitter.com/bittrex', 'https://twitter.com/bittrex2']
+};
+
 
 describe('descriptorData', () => {
     describe('get', () => {
@@ -35,6 +49,33 @@ describe('descriptorData', () => {
             expect(descriptor.get()).toEqual(
                 {
                     'alias': 'somealias',
+                    'avatar': {
+                        'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
+                        'mimeType': 'image/gif',
+                    },
+                    'background': {
+                        'ipfsCid': 'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc',
+                        'mimeType': 'image/jpeg',
+                    },
+                    'description': 'World class exchange at your service',
+                    'extension': 'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc',
+                    'homePage': 'https://bittrex.com',
+                    'name': 'Bittrex',
+                    'sendRule': /^[0-9a-fA-F]{24}$/,
+                    'socialMediaLinks': [
+                        'https://twitter.com/bittrex',
+                        'https://twitter.com/bittrex2',
+                    ],
+                    'type': 'cex',
+                    'version': 1,
+                }
+            );
+        });
+        it('should return a human friendly object with alias TLD', () => {
+            const descriptor = DescriptorData.parse(JSON.stringify(TestObjectAliasTld));
+            expect(descriptor.get()).toEqual(
+                {
+                    'alias': 'somealias.mytld',
                     'avatar': {
                         'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
                         'mimeType': 'image/gif',
@@ -125,7 +166,7 @@ describe('descriptorData', () => {
                     'vs': 1,
                     'al': '@somealias',
                 }));
-            }).toThrow('[SRC44 Validation Error]: al must match /^\\w{1,100}$/ - Got @somealias');
+            }).toThrow('[SRC44 Validation Error]: al must match /^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$/ - Got @somealias');
         });
 
         it('should throw exception if object is not valid - 2', () => {

--- a/packages/standards/src/src44/__tests__/descriptorData.spec.ts
+++ b/packages/standards/src/src44/__tests__/descriptorData.spec.ts
@@ -36,7 +36,7 @@ const TestObjectAliasTld = {
     'bg': {'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc': 'image/jpeg'},
     'hp': 'https://bittrex.com',
     'sr': '^[0-9a-fA-F]{24}$',
-    'al': 'somealias.mytld',
+    'al': 'somealias:mytld',
     'xt': 'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc',
     'sc': ['https://twitter.com/bittrex', 'https://twitter.com/bittrex2']
 };
@@ -75,7 +75,7 @@ describe('descriptorData', () => {
             const descriptor = DescriptorData.parse(JSON.stringify(TestObjectAliasTld));
             expect(descriptor.get()).toEqual(
                 {
-                    'alias': 'somealias.mytld',
+                    'alias': 'somealias:mytld',
                     'avatar': {
                         'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
                         'mimeType': 'image/gif',
@@ -166,7 +166,7 @@ describe('descriptorData', () => {
                     'vs': 1,
                     'al': '@somealias',
                 }));
-            }).toThrow('[SRC44 Validation Error]: al must match /^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$/ - Got @somealias');
+            }).toThrow('[SRC44 Validation Error]: al must match /^\\w{1,100}(\\:[a-zA-Z0-9]{1,40})?$/ - Got @somealias');
         });
 
         it('should throw exception if object is not valid - 2', () => {

--- a/packages/standards/src/src44/__tests__/descriptorDataBuilder.spec.ts
+++ b/packages/standards/src/src44/__tests__/descriptorDataBuilder.spec.ts
@@ -52,7 +52,7 @@ describe('descriptorDataBuilder', () => {
                 .build();
 
             expect(descriptorData.raw).toEqual({
-                'al': 'alias.mytld',
+                'al': 'alias:mytld',
                 'nm': 'Some name',
                 'vs': 1,
             });

--- a/packages/standards/src/src44/__tests__/descriptorDataBuilder.spec.ts
+++ b/packages/standards/src/src44/__tests__/descriptorDataBuilder.spec.ts
@@ -44,6 +44,19 @@ describe('descriptorDataBuilder', () => {
                 'xt': 'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc'
             });
         });
+        it('should create/build as expected using tld', () => {
+            const descriptorData = DescriptorDataBuilder
+                .create()
+                .setName('Some name')
+                .setAlias('alias', 'mytld')
+                .build();
+
+            expect(descriptorData.raw).toEqual({
+                'al': 'alias.mytld',
+                'nm': 'Some name',
+                'vs': 1,
+            });
+        });
 
         it('should throw exception on invalid data - wrong mime type', () => {
             expect(() => {

--- a/packages/standards/src/src44/__tests__/descriptorDataClient.spec.ts
+++ b/packages/standards/src/src44/__tests__/descriptorDataClient.spec.ts
@@ -2,7 +2,7 @@ import {DescriptorDataBuilder} from '../DescriptorDataBuilder';
 import {DescriptorDataClient} from '../DescriptorDataClient';
 
 const MockDescriptor = {
-    'al': 'alias.tld',
+    'al': 'alias:tld',
     'ac': '895212263565386113',
     'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
     'av': {'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR': 'image/gif'},
@@ -60,7 +60,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const descriptor = await client.getFromContract('1');
             expect(descriptor).toEqual({
-                'alias': 'alias.tld',
+                'alias': 'alias:tld',
                 'account': '895212263565386113',
                 'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                 'avatar': {
@@ -76,7 +76,7 @@ describe('descriptorDataClient', () => {
                 'homePage': 'https://homepage.com',
                 'name': 'Some name',
                 'resolvedAlias': {
-                    'alias': 'alias.tld',
+                    'alias': 'alias:tld',
                     'account': '895212263565386113',
                     'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                     'avatar': {
@@ -115,7 +115,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const descriptor = await client.getFromAsset('1');
             expect(descriptor).toEqual({
-                'alias': 'alias.tld',
+                'alias': 'alias:tld',
                 'account': '895212263565386113',
                 'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                 'avatar': {
@@ -131,7 +131,7 @@ describe('descriptorDataClient', () => {
                 'homePage': 'https://homepage.com',
                 'name': 'Some name',
                 'resolvedAlias': {
-                    'alias': 'alias.tld',
+                    'alias': 'alias:tld',
                     'account': '895212263565386113',
                     'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                     'avatar': {
@@ -170,7 +170,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const descriptor = await client.getFromAccount('1');
             expect(descriptor).toEqual({
-                'alias': 'alias.tld',
+                'alias': 'alias:tld',
                 'account': '895212263565386113',
                 'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
 
@@ -187,7 +187,7 @@ describe('descriptorDataClient', () => {
                 'homePage': 'https://homepage.com',
                 'name': 'Some name',
                 'resolvedAlias': {
-                    'alias': 'alias.tld',
+                    'alias': 'alias:tld',
                     'account': '895212263565386113',
                     'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
 
@@ -298,7 +298,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const descriptor = await client.getFromAlias('alias');
             expect(descriptor).toEqual({
-                'alias': 'alias.tld',
+                'alias': 'alias:tld',
                 'account': '895212263565386113',
                 'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                 'avatar': {
@@ -329,7 +329,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const account = await client.getAccountByAlias('alias');
             expect(account).toEqual({
-                'description': '{"al":"alias.tld","ac":"895212263565386113","id":"dc1de06b-a2a2-4a6e-b3e1-a5d97835667d","av":{"QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR":"image/gif"},"bg":{"QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc":"image/jpeg"},"ds":"description","hp":"https://homepage.com","nm":"Some name","sc":["https://somelink.com"],"sr":"^[a-z]{3}$","tp":"oth","vs":1,"xc":"value","xt":"QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc"}',
+                'description': '{"al":"alias:tld","ac":"895212263565386113","id":"dc1de06b-a2a2-4a6e-b3e1-a5d97835667d","av":{"QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR":"image/gif"},"bg":{"QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc":"image/jpeg"},"ds":"description","hp":"https://homepage.com","nm":"Some name","sc":["https://somelink.com"],"sr":"^[a-z]{3}$","tp":"oth","vs":1,"xc":"value","xt":"QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc"}',
                 'name': 'Account Name',
             });
         });
@@ -355,7 +355,7 @@ describe('descriptorDataClient', () => {
             expect(brands).toHaveLength(1);
             expect(brands[0]).toEqual({
                 'account': '895212263565386113',
-                'alias': 'alias.tld',
+                'alias': 'alias:tld',
                 'avatar': {
                     'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
                     'mimeType': 'image/gif'
@@ -406,7 +406,7 @@ describe('descriptorDataClient', () => {
             expect(brands).toHaveLength(1);
             expect(brands[0]).toEqual({
                 'account': '895212263565386113',
-                'alias': 'alias.tld',
+                'alias': 'alias:tld',
                 'avatar': {
                     'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
                     'mimeType': 'image/gif'
@@ -483,7 +483,7 @@ describe('descriptorDataClient', () => {
             expect(brands).toHaveLength(1);
             expect(brands[0]).toEqual({
                 'account': '895212263565386113',
-                'alias': 'alias.tld',
+                'alias': 'alias:tld',
                 'avatar': {
                     'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
                     'mimeType': 'image/gif'

--- a/packages/standards/src/src44/__tests__/descriptorDataClient.spec.ts
+++ b/packages/standards/src/src44/__tests__/descriptorDataClient.spec.ts
@@ -2,7 +2,7 @@ import {DescriptorDataBuilder} from '../DescriptorDataBuilder';
 import {DescriptorDataClient} from '../DescriptorDataClient';
 
 const MockDescriptor = {
-    'al': 'alias',
+    'al': 'alias.tld',
     'ac': '895212263565386113',
     'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
     'av': {'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR': 'image/gif'},
@@ -60,7 +60,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const descriptor = await client.getFromContract('1');
             expect(descriptor).toEqual({
-                'alias': 'alias',
+                'alias': 'alias.tld',
                 'account': '895212263565386113',
                 'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                 'avatar': {
@@ -76,7 +76,7 @@ describe('descriptorDataClient', () => {
                 'homePage': 'https://homepage.com',
                 'name': 'Some name',
                 'resolvedAlias': {
-                    'alias': 'alias',
+                    'alias': 'alias.tld',
                     'account': '895212263565386113',
                     'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                     'avatar': {
@@ -115,7 +115,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const descriptor = await client.getFromAsset('1');
             expect(descriptor).toEqual({
-                'alias': 'alias',
+                'alias': 'alias.tld',
                 'account': '895212263565386113',
                 'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                 'avatar': {
@@ -131,7 +131,7 @@ describe('descriptorDataClient', () => {
                 'homePage': 'https://homepage.com',
                 'name': 'Some name',
                 'resolvedAlias': {
-                    'alias': 'alias',
+                    'alias': 'alias.tld',
                     'account': '895212263565386113',
                     'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                     'avatar': {
@@ -170,7 +170,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const descriptor = await client.getFromAccount('1');
             expect(descriptor).toEqual({
-                'alias': 'alias',
+                'alias': 'alias.tld',
                 'account': '895212263565386113',
                 'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
 
@@ -187,7 +187,7 @@ describe('descriptorDataClient', () => {
                 'homePage': 'https://homepage.com',
                 'name': 'Some name',
                 'resolvedAlias': {
-                    'alias': 'alias',
+                    'alias': 'alias.tld',
                     'account': '895212263565386113',
                     'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
 
@@ -298,7 +298,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const descriptor = await client.getFromAlias('alias');
             expect(descriptor).toEqual({
-                'alias': 'alias',
+                'alias': 'alias.tld',
                 'account': '895212263565386113',
                 'id': 'dc1de06b-a2a2-4a6e-b3e1-a5d97835667d',
                 'avatar': {
@@ -329,7 +329,7 @@ describe('descriptorDataClient', () => {
             const client = new DescriptorDataClient(MockLedger);
             const account = await client.getAccountByAlias('alias');
             expect(account).toEqual({
-                'description': '{"al":"alias","ac":"895212263565386113","id":"dc1de06b-a2a2-4a6e-b3e1-a5d97835667d","av":{"QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR":"image/gif"},"bg":{"QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc":"image/jpeg"},"ds":"description","hp":"https://homepage.com","nm":"Some name","sc":["https://somelink.com"],"sr":"^[a-z]{3}$","tp":"oth","vs":1,"xc":"value","xt":"QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc"}',
+                'description': '{"al":"alias.tld","ac":"895212263565386113","id":"dc1de06b-a2a2-4a6e-b3e1-a5d97835667d","av":{"QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR":"image/gif"},"bg":{"QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc":"image/jpeg"},"ds":"description","hp":"https://homepage.com","nm":"Some name","sc":["https://somelink.com"],"sr":"^[a-z]{3}$","tp":"oth","vs":1,"xc":"value","xt":"QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc"}',
                 'name': 'Account Name',
             });
         });
@@ -355,7 +355,7 @@ describe('descriptorDataClient', () => {
             expect(brands).toHaveLength(1);
             expect(brands[0]).toEqual({
                 'account': '895212263565386113',
-                'alias': 'alias',
+                'alias': 'alias.tld',
                 'avatar': {
                     'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
                     'mimeType': 'image/gif'
@@ -406,7 +406,7 @@ describe('descriptorDataClient', () => {
             expect(brands).toHaveLength(1);
             expect(brands[0]).toEqual({
                 'account': '895212263565386113',
-                'alias': 'alias',
+                'alias': 'alias.tld',
                 'avatar': {
                     'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
                     'mimeType': 'image/gif'
@@ -483,7 +483,7 @@ describe('descriptorDataClient', () => {
             expect(brands).toHaveLength(1);
             expect(brands[0]).toEqual({
                 'account': '895212263565386113',
-                'alias': 'alias',
+                'alias': 'alias.tld',
                 'avatar': {
                     'ipfsCid': 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
                     'mimeType': 'image/gif'

--- a/packages/standards/src/src44/__tests__/validateSRC44.spec.ts
+++ b/packages/standards/src/src44/__tests__/validateSRC44.spec.ts
@@ -15,7 +15,7 @@ describe('validateSRC44', () => {
                 'bg': { 'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc': 'image/jpeg' },
                 'hp': 'https://bittrex.com',
                 'sr': '^[0-9a-fA-F]{24}$',
-                'al': 'somealias',
+                'al': 'somealias_newFormat',
                 'xt': 'QmUFc4dyX7TJn5dPxp8CrcDeedoV18owTBUWApYMuF6Koc',
                 'sc': ['https://twitter.com/bittrex']
             });
@@ -195,7 +195,7 @@ describe('validateSRC44', () => {
                     nm: 'name',
                     al: '@invalid alias'
                 });
-            }).toThrow('al must match /^\\w{1,100}$/ - Got @invalid alias');
+            }).toThrow('[SRC44 Validation Error]: al must match /^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$/ - Got @invalid alias');
         });
         it('throws error for beign too large', () => {
             expect(() => {
@@ -204,7 +204,7 @@ describe('validateSRC44', () => {
                     nm: 'name',
                     al: 'alias'.repeat(30)
                 });
-            }).toThrow('al must match /^\\w{1,100}$/');
+            }).toThrow('al must match /^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$/');
         });
     });
 

--- a/packages/standards/src/src44/__tests__/validateSRC44.spec.ts
+++ b/packages/standards/src/src44/__tests__/validateSRC44.spec.ts
@@ -195,7 +195,7 @@ describe('validateSRC44', () => {
                     nm: 'name',
                     al: '@invalid alias'
                 });
-            }).toThrow('[SRC44 Validation Error]: al must match /^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$/ - Got @invalid alias');
+            }).toThrow('[SRC44 Validation Error]: al must match /^\\w{1,100}(\\:[a-zA-Z0-9]{1,40})?$/ - Got @invalid alias');
         });
         it('throws error for beign too large', () => {
             expect(() => {
@@ -204,7 +204,7 @@ describe('validateSRC44', () => {
                     nm: 'name',
                     al: 'alias'.repeat(30)
                 });
-            }).toThrow('al must match /^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$/');
+            }).toThrow('al must match /^\\w{1,100}(\\:[a-zA-Z0-9]{1,40})?$/');
         });
     });
 

--- a/packages/standards/src/src44/schema-descriptor.json
+++ b/packages/standards/src/src44/schema-descriptor.json
@@ -151,7 +151,7 @@
       "type": "string",
       "title": "The referenced Alias",
       "description": "An related alias of the Signum chain, that can mutable on-chain information",
-      "pattern": "^\\w{1,100}$",
+      "pattern": "^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$",
       "default": "",
       "examples": [
         "@myAlias123"

--- a/packages/standards/src/src44/schema-descriptor.json
+++ b/packages/standards/src/src44/schema-descriptor.json
@@ -151,7 +151,7 @@
       "type": "string",
       "title": "The referenced Alias",
       "description": "An related alias of the Signum chain, that can mutable on-chain information",
-      "pattern": "^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$",
+      "pattern": "^\\w{1,100}(:[a-zA-Z0-9]{1,40})?$",
       "default": "",
       "examples": [
         "@myAlias123"

--- a/packages/standards/src/src44/validateSRC44.ts
+++ b/packages/standards/src/src44/validateSRC44.ts
@@ -48,8 +48,8 @@ export function validateSRC44(json: SRC44Descriptor, strict = true) {
             throw new Error(`id must be at maximum ${IdLength} bytes - Got ${json.id.length}`);
         }
 
-        if (json.al && !/^\w{1,100}$/.test(json.al)) {
-            throw new Error(`al must match /^\\w{1,100}$/ - Got ${json.al}`);
+        if (json.al && !/^\w{1,100}(\.[a-zA-Z0-9]{1,40})?$/.test(json.al)) {
+            throw new Error(`al must match /^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$/ - Got ${json.al}`);
         }
 
         if (json.ac && !/^\d{10,22}$/.test(json.ac)) {

--- a/packages/standards/src/src44/validateSRC44.ts
+++ b/packages/standards/src/src44/validateSRC44.ts
@@ -48,8 +48,8 @@ export function validateSRC44(json: SRC44Descriptor, strict = true) {
             throw new Error(`id must be at maximum ${IdLength} bytes - Got ${json.id.length}`);
         }
 
-        if (json.al && !/^\w{1,100}(\.[a-zA-Z0-9]{1,40})?$/.test(json.al)) {
-            throw new Error(`al must match /^\\w{1,100}(\\.[a-zA-Z0-9]{1,40})?$/ - Got ${json.al}`);
+        if (json.al && !/^\w{1,100}(\:[a-zA-Z0-9]{1,40})?$/.test(json.al)) {
+            throw new Error(`al must match /^\\w{1,100}(\\:[a-zA-Z0-9]{1,40})?$/ - Got ${json.al}`);
         }
 
         if (json.ac && !/^\d{10,22}$/.test(json.ac)) {


### PR DESCRIPTION
SRC44 Descriptor data supports now `al` field with optional appended tld, i.e.

```json
{
   "vs": 1,
   "al": "my_alias:withtld"
}
```