### PR TITLE
docs: update sendsigna

### DIFF
--- a/examples/nodejs/intermediate/sendSigna.js
+++ b/examples/nodejs/intermediate/sendSigna.js
@@ -72,7 +72,7 @@ async function sendSigna(args) {
         // Now, we execute the transaction
         // within the method the local signing flow is being executed, i.e.
         // the private key is used only locally for signinh, but never sent over the network
-        const {transactionJSON} = await ledger.transaction.sendAmountToSingleRecipient(
+        const transactionData = await ledger.transaction.sendAmountToSingleRecipient(
             {
                 recipientId,
                 amountPlanck: Amount.fromSigna(amount).getPlanck(),
@@ -82,10 +82,13 @@ async function sendSigna(args) {
             }
         );
 
-        // now, some final nice message
-        const addressPrefix = ledgerType === 'MainNet' ? AddressPrefix.MainNet : AddressPrefix.TestNet
-        console.info(`Successfully sent ${amount} ${CurrencySymbol} to ${Address.create(recipientId, addressPrefix).getReedSolomonAddress()} - Transaction Id: ${transaction}`)
-        console.info(`You paid a total of ${Amount.fromSigna(amount).add(Amount.fromPlanck(selectedFeePlanck)).toString()}`)
+        if ('transaction' in transactionData)
+        {
+            // now, some final nice message
+            const addressPrefix = ledgerType === 'MainNet' ? AddressPrefix.MainNet : AddressPrefix.TestNet
+            console.info(`Successfully sent ${amount} ${CurrencySymbol} to ${Address.create(recipientId, addressPrefix).getReedSolomonAddress()} - Transaction Id: ${transaction}`)
+            console.info(`You paid a total of ${Amount.fromSigna(amount).add(Amount.fromPlanck(selectedFeePlanck)).toString()}`)            
+        }
     } catch (e) {
         // If the API returns an exception,
         // the return error object is of type HttpError

--- a/examples/nodejs/intermediate/sendSigna.js
+++ b/examples/nodejs/intermediate/sendSigna.js
@@ -72,7 +72,7 @@ async function sendSigna(args) {
         // Now, we execute the transaction
         // within the method the local signing flow is being executed, i.e.
         // the private key is used only locally for signinh, but never sent over the network
-        const {transaction} = await ledger.transaction.sendAmountToSingleRecipient(
+        const {transactionJSON} = await ledger.transaction.sendAmountToSingleRecipient(
             {
                 recipientId,
                 amountPlanck: Amount.fromSigna(amount).getPlanck(),


### PR DESCRIPTION
Based on `transactionApi.d.ts`, `sendAmountToSingleRecipient` is the following type:
```
sendAmountToSingleRecipient: (args: SendAmountArgs) => Promise<TransactionId | UnsignedTransaction>;
```

When using this in the way the documentation specifies, TypeScript cannot guarantee that it is a signed transaction.
You must verify the key exists until typing's dynamically change based on parameters.